### PR TITLE
Fix package vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1537,7 +1537,7 @@
         "url-loader": "^1.1.2",
         "vue-loader": "^15.7.0",
         "webpack": ">=4 < 4.29",
-        "webpack-bundle-analyzer": "^3.3.0",
+        "webpack-bundle-analyzer": "^3.3.2",
         "webpack-chain": "^4.11.0",
         "webpack-dev-server": "^3.3.1",
         "webpack-merge": "^4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6224,9 +6224,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -12150,12 +12150,12 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },


### PR DESCRIPTION
Run `npm audit fix` to fix security vulnerabilities [WS-2019-0058](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/263) from **`webpack-bundle-analyzer`**